### PR TITLE
Replace type assertions in useTwitchContext and useTwitchCurrentUser

### DIFF
--- a/src/hooks/useTwitchContext.tsx
+++ b/src/hooks/useTwitchContext.tsx
@@ -2,5 +2,12 @@ import { useContext } from 'react';
 import { TwitchAPIContext } from '../api/context';
 import { TwitchAPIContextProps } from '../api/interfaces';
 
-export const useTwitchContext = (): TwitchAPIContextProps =>
-  useContext(TwitchAPIContext) as TwitchAPIContextProps;
+export const useTwitchContext = (): TwitchAPIContextProps => {
+  const context = useContext(TwitchAPIContext);
+
+  if (context === undefined) {
+    throw new Error('useTwitchContext must be used within a TwitchProvider')
+  }
+
+  return context;
+}

--- a/src/hooks/useTwitchCurrentUser.tsx
+++ b/src/hooks/useTwitchCurrentUser.tsx
@@ -2,5 +2,12 @@ import { useContext } from 'react';
 import { TwitchCurrentUserContext } from '../currentUser/context';
 import { TwitchCurrentUserProps } from '../currentUser/interfaces';
 
-export const useTwitchCurrentUser = (): TwitchCurrentUserProps =>
-  useContext(TwitchCurrentUserContext) as TwitchCurrentUserProps;
+export const useTwitchCurrentUser = (): TwitchCurrentUserProps => {
+  const context = useContext(TwitchCurrentUserContext);
+
+  if (context === undefined) {
+    throw new Error('useTwitchCurrentUser must be used within a TwitchProvider')
+  }
+
+  return context;
+}


### PR DESCRIPTION
Type assertions should be avoided unless you're 100% sure you know better than TS.
Here, even if these hooks are used internally only, it helps to guide users with a better error message when something goes wrong.