### PR TITLE
Remove React default imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,9 +14,22 @@
     // "prettier"
   ],
   "rules": {
+    "no-restricted-imports": [1, {
+      "paths": [{
+        "name": "react",
+        "importNames": ["default"],
+        "message": "Use named imports instead."
+      }, {
+        "name": "react-dom",
+        "importNames": ["default"],
+        "message": "Use named imports instead."
+      }]
+    }],
     "react-hooks/rules-of-hooks": 2,
     "react-hooks/exhaustive-deps": 1,
+    "react/jsx-uses-react": 0,
     "react/prop-types": 0,
+    "react/react-in-jsx-scope": 0,
     // "prettier/prettier": [
     //   "error",
     //   {

--- a/src/api/Provider.tsx
+++ b/src/api/Provider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useReducer } from 'react';
+import { FC, useCallback, useEffect, useReducer } from 'react';
 import { TwitchAPIContext } from './context';
 import { getHTTPClient } from './helpers';
 import { apiRequestReducer } from './reducer';

--- a/src/components/TwitchProvider.tsx
+++ b/src/components/TwitchProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { redirectForToken } from '../api/helpers';
 import { TwitchAPIProvider } from '../api/Provider';
 import { TwitchCurrentUserProvider } from '../currentUser/Provider';

--- a/src/components/atoms/FollowerCount.tsx
+++ b/src/components/atoms/FollowerCount.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTwitchApi } from '../../hooks/useTwitchApi';
 import { TwitchUsersFollowsResponse } from '../../interfaces';
 import { useTwitchCurrentUser } from '../../hooks/useTwitchCurrentUser';

--- a/src/components/atoms/LatestFollower.tsx
+++ b/src/components/atoms/LatestFollower.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTwitchApi } from '../../hooks/useTwitchApi';
 import { TwitchUsersFollowsResponse } from '../../interfaces';
 import { useTwitchCurrentUser } from '../../hooks/useTwitchCurrentUser';

--- a/src/components/atoms/LatestSubscriber.tsx
+++ b/src/components/atoms/LatestSubscriber.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTwitchApi } from '../../hooks/useTwitchApi';
 import { TwitchBroadcasterSubscriptionsResponse } from '../../interfaces';
 import { useTwitchCurrentUser } from '../../hooks/useTwitchCurrentUser';

--- a/src/components/atoms/SubscriberCount.tsx
+++ b/src/components/atoms/SubscriberCount.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTwitchApi } from '../../hooks/useTwitchApi';
 import { TwitchBroadcasterSubscriptionsResponse } from '../../interfaces';
 import { useTwitchCurrentUser } from '../../hooks/useTwitchCurrentUser';

--- a/src/components/atoms/UserDisplayName.tsx
+++ b/src/components/atoms/UserDisplayName.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTwitchCurrentUser } from '../../hooks/useTwitchCurrentUser';
 
 export const UserDisplayName: FC = () => {

--- a/src/components/molecules/FollowerGoal.tsx
+++ b/src/components/molecules/FollowerGoal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTwitchApi } from '../../hooks/useTwitchApi';
 import { TwitchUsersFollowsResponse } from '../../interfaces';
 import { useTwitchCurrentUser } from '../../hooks/useTwitchCurrentUser';

--- a/src/components/molecules/SubscriberGoal.tsx
+++ b/src/components/molecules/SubscriberGoal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { useTwitchApi } from '../../hooks/useTwitchApi';
 import { TwitchBroadcasterSubscriptionsResponse } from '../../interfaces';
 import { useTwitchCurrentUser } from '../../hooks/useTwitchCurrentUser';

--- a/src/components/molecules/internal/LoadingBar.tsx
+++ b/src/components/molecules/internal/LoadingBar.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css, cx } from '@emotion/css';
 
 const progressBarStyles = css`

--- a/src/components/templates/games/Overwatch.tsx
+++ b/src/components/templates/games/Overwatch.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { FC, ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import { FollowerGoal } from '../../molecules/FollowerGoal';
 import { css } from '@emotion/css';
 import { SubscriberGoal } from '../../molecules/SubscriberGoal';

--- a/src/currentUser/Provider.tsx
+++ b/src/currentUser/Provider.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { TwitchUsersResponse } from '../interfaces';
 import { TwitchCurrentUserContext } from './context';
 import { useTwitchApi } from '../hooks/useTwitchApi';

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import './button.css';
 
 export interface ButtonProps {

--- a/src/stories/Header.stories.tsx
+++ b/src/stories/Header.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from './Button';
 import './header.css';
 

--- a/src/stories/MoleculeFollowerGoal.stories.tsx
+++ b/src/stories/MoleculeFollowerGoal.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import { ComponentProps } from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 

--- a/src/stories/MoleculeFollowerGoal.tsx
+++ b/src/stories/MoleculeFollowerGoal.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, FC } from 'react';
+import { ComponentProps, FC } from 'react';
 import './button.css';
 import { TwitchProvider } from '../components/TwitchProvider';
 import { FollowerGoal } from '../components/molecules/FollowerGoal';

--- a/src/stories/MoleculeSubscriberGoal.stories.tsx
+++ b/src/stories/MoleculeSubscriberGoal.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import { ComponentProps } from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 

--- a/src/stories/MoleculeSubscriberGoal.tsx
+++ b/src/stories/MoleculeSubscriberGoal.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, FC } from 'react';
+import { ComponentProps, FC } from 'react';
 import './button.css';
 import { TwitchProvider } from '../components/TwitchProvider';
 import { SubscriberGoal } from '../components/molecules/SubscriberGoal';

--- a/src/stories/Page.stories.tsx
+++ b/src/stories/Page.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 

--- a/src/stories/Page.tsx
+++ b/src/stories/Page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Header } from './Header';
 import './page.css';
 

--- a/src/stories/TemplateGameOverwatch.stories.tsx
+++ b/src/stories/TemplateGameOverwatch.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { TemplateGameOverwatchStory } from './TemplateGameOverwatch';

--- a/src/stories/TemplateGameOverwatch.tsx
+++ b/src/stories/TemplateGameOverwatch.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import './button.css';
 import { TwitchProvider } from '../components/TwitchProvider';
 import { TwitchWrapper } from '../template/TwitchWrapper';

--- a/src/stories/UserDisplayName.stories.tsx
+++ b/src/stories/UserDisplayName.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { UserDisplayNameStory } from './UserDisplayName';

--- a/src/stories/UserDisplayName.tsx
+++ b/src/stories/UserDisplayName.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { TwitchProvider } from '../components/TwitchProvider';
 import { UserDisplayName } from '../components/atoms/UserDisplayName';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "lib": ["esnext", "dom", "dom.iterable"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
With the new [jsx transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html), we don't need to import the default export from `react`.